### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Secure Password Storage v2.0
 
 [![Build Status](https://travis-ci.org/defuse/password-hashing.svg?branch=master)](https://travis-ci.org/defuse/password-hashing)
 
-This repository containes peer-reviewed libraries for password storage in PHP,
+This repository contains peer-reviewed libraries for password storage in PHP,
 C#, Ruby, and Java. Passwords are "hashed" with PBKDF2 (32,000 iterations of
 SHA1 by default) using a cryptographically-random salt. The implementations are
 compatible with each other, so you can, for instance, create a hash in PHP and


### PR DESCRIPTION
Ironic that there's a huge typo in the README right beside the word "peer-reviewed."