### PR TITLE
 Remove javax.xml dependency for base64 

### DIFF
--- a/PasswordStorage.java
+++ b/PasswordStorage.java
@@ -4,7 +4,7 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.SecretKeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64; 
 
 public class PasswordStorage
 {
@@ -190,12 +190,12 @@ public class PasswordStorage
     private static byte[] fromBase64(String hex)
         throws IllegalArgumentException
     {
-        return DatatypeConverter.parseBase64Binary(hex);
+         return Base64.getDecoder().decode(hex);     
     }
 
     private static String toBase64(byte[] array)
     {
-        return DatatypeConverter.printBase64Binary(array);
+         return Base64.getEncoder().encodeToString(array);
     }
 
 }

--- a/PasswordStorage.java
+++ b/PasswordStorage.java
@@ -190,12 +190,12 @@ public class PasswordStorage
     private static byte[] fromBase64(String hex)
         throws IllegalArgumentException
     {
-         return Base64.getDecoder().decode(hex);     
+        return Base64.getDecoder().decode(hex);
     }
 
     private static String toBase64(byte[] array)
     {
-         return Base64.getEncoder().encodeToString(array);
+        return Base64.getEncoder().encodeToString(array);
     }
 
 }


### PR DESCRIPTION
The `javax.xml` module was removed in recent Java versions. The `java.util.Base64` class can be used instead, which supports both older and newer versions.

(Was fixing this for another project, they suggested that I update this as well [here](https://github.com/Rsl1122/Plan-PlayerAnalytics/pull/830#issuecomment-443705033))